### PR TITLE
README.md: fix HAR log method (GET not CUSTOM)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ const har = {
       {
         index: 0,
         request: {
-          method: "CUSTOM",
+          method: "GET",
           url: "http://test.loadimpact.com/login",
           headers: [
             {

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ const har = {
       {
         index: 0,
         request: {
-          method: "GET",
+          method: "POST",
           url: "http://test.loadimpact.com/login",
           headers: [
             {


### PR DESCRIPTION
Seems like validation checks inside generateSpecs are checking if method is standard and dropping non-standard method entries.

fixes #8 